### PR TITLE
support link with "&"

### DIFF
--- a/lib/videotime.rb
+++ b/lib/videotime.rb
@@ -2,7 +2,7 @@ require "videotime/version"
 
 module Videotime
   def self.get_video_time(path)
-	result = `ffmpeg -i #{path} 2>&1`
+	result = `ffmpeg -i "#{path}" 2>&1`
     r = result.match("Duration: ([0-9]+):([0-9]+):([0-9]+).([0-9]+)")
     duration = r[1].to_i*3600+r[2].to_i*60+r[3].to_i if r
   end


### PR DESCRIPTION
If there is a '&' in video path, the param after & will be Intercepted，so it can't get the right video path and video time. 
example link : https://example.com/example.mp4?auth_key=1&Expires=1567684968 
Quotes fix the feature.